### PR TITLE
Add a bugfix for long path

### DIFF
--- a/plex_mobile.css
+++ b/plex_mobile.css
@@ -479,3 +479,5 @@ div[class*="NavBar-buttonSeparator-"] {
     display: none;
   }
 }
+/* Bugfix: File path too long */
+.media-info-file-list > li { word-break: break-all; }

--- a/plex_mobile.css
+++ b/plex_mobile.css
@@ -480,4 +480,6 @@ div[class*="NavBar-buttonSeparator-"] {
   }
 }
 /* Bugfix: File path too long */
-.media-info-file-list > li { word-break: break-all; }
+.media-info-file-list>li {
+  word-break: break-all;
+}


### PR DESCRIPTION
Fix the following bug on mobile/desktop: 

![image](https://user-images.githubusercontent.com/8138585/73017340-f09dc080-3e1f-11ea-8b6b-276bf88f8944.png)

(The text overflow the content and we can't see a part of the file path)
